### PR TITLE
hg::DisableCursor() on SDL is not implemented

### DIFF
--- a/harfang/platform/sdl/window_system.cpp
+++ b/harfang/platform/sdl/window_system.cpp
@@ -189,6 +189,7 @@ hg::Vec2 GetWindowContentScale(const Window *window) {
 
 void ShowCursor() { SDL_ShowCursor(SDL_ENABLE); }
 void HideCursor() { SDL_ShowCursor(SDL_DISABLE); }
+void DisableCursor() { SDL_ShowCursor(SDL_DISABLE); }
 void WindowSystemShutdown() { }
 
 } // namespace hg

--- a/harfang/platform/sdl/window_system.cpp
+++ b/harfang/platform/sdl/window_system.cpp
@@ -189,7 +189,7 @@ hg::Vec2 GetWindowContentScale(const Window *window) {
 
 void ShowCursor() { SDL_ShowCursor(SDL_ENABLE); }
 void HideCursor() { SDL_ShowCursor(SDL_DISABLE); }
-void DisableCursor() { SDL_ShowCursor(SDL_DISABLE); }
+void DisableCursor() { SDL_SetRelativeMouseMode(SDL_ENABLE); }
 void WindowSystemShutdown() { }
 
 } // namespace hg

--- a/harfang/platform/sdl/window_system.cpp
+++ b/harfang/platform/sdl/window_system.cpp
@@ -189,7 +189,7 @@ hg::Vec2 GetWindowContentScale(const Window *window) {
 
 void ShowCursor() { SDL_ShowCursor(SDL_ENABLE); }
 void HideCursor() { SDL_ShowCursor(SDL_DISABLE); }
-void DisableCursor() { SDL_SetRelativeMouseMode(SDL_ENABLE); }
+void DisableCursor() { SDL_SetRelativeMouseMode(SDL_TRUE); }
 void WindowSystemShutdown() { }
 
 } // namespace hg


### PR DESCRIPTION
but is required for wasm static linking.